### PR TITLE
Change HTML document crafting usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,93 +11,53 @@ You can install the package with pip:
 pip install dash-htmlayout
 ```
 
+## Documentation
+
+[Read documentation to learn momre](https://github.com/artscoop/dash-htmlayout/blob/7b35a33e8d7106e276aba06a06b9e8e4e681e18b/pyproject.toml#L26)
+
 ## Introduction
 
 It's a bit counterproductive to force users to build dashboard
 layouts using Python, when most component classes are translated
 into HTML.
 
-Having to write code such as the following:
-
-```python
-app.layout = html.Section()
-app.layout.children = [
-    html.H1("Dashboard component.", className="mb-5"),
-    html.Div(
-        className="row",
-        children=[
-            html.Div(
-                className="col-3",
-                children=[
-                    html.Div(
-                        className="form-group mb-3",
-                        children=[
-                            html.Label("Genres filter"),
-                            dcc.Dropdown(
-                                id="genre-list",
-                                placeholder="Filter genres",
-                                multi=True,
-                            ),
-                        ],
-                    ),
-                    html.Div(
-                        className="form-group mb-3",
-                        children=[
-                            html.Label("Max results"),
-                            dcc.Slider(
-                                id="genre-limit", min=5, max=15, step=1, value=10
-                            ),
-                        ],
-                    ),
-                ],
-            ),
-            html.Div(
-                className="col-5 d-flex align-items-stretch",
-                children=[
-                    html.Div(className="card flex-fill", children=[
-                        html.H2("Genre information", className="text-center card-header"),
-                        html.Div(className="card-body", children=[
-                            dcc.Graph(id="genre-info"),
-                        ]),
-                    ]),
-                ],
-            ),
-            html.Div(
-                className="col-4 d-flex align-items-stretch flex-fill",
-                children=[
-                    html.Div(className="card flex-fill", children=[
-                        html.H2("Artists", className="text-center card-header"),
-                        dcc.Markdown(id="artist-info", className="card-body"),
-                    ]),
-                ],
-            ),
-        ],
-    ),
-]
-```
-
+Having to write code with deeply nested object instances to mimic HTML
 should almost be considered malpractice in Python when there is a language
 and a document type that addresses this exact need; HTML.
 
-Instead, this package provides a simple class to generate layouts
-from a partial HTML document. For example, we could partially reproduce the above
-example with such a file:
+This package provides a simple class to generate layouts
+from a partial HTML snippet. For example, we could partially reproduce a classic
+layout with the following document:
 
 ```html
+<!-- Example with Bootstrap classes and some components -->
 <section>
     <h1 class="mb-5">Dashboard component.</h1>
     <div class="row">
         <div class="col-3">
             <div class="form-group mb-3">
                 <label for="">Genres filter</label>
-                <dcc.dropdown id="genre-list" placeholder="Filter genres" multi/>
+                <dcc-dropdown id="genre-list" placeholder="Filter genres" data-multi="True"/>
             </div>
             <div class="form-group mb-3">
                 <label for="">Max results</label>
-                <dcc.slider id="genre-limit" min=5 max=15 step=1 value=10/>
+                <dcc-slider id="genre-limit" data-value="1" data-min="0" data-max="10"/>
             </div>
         </div>
         ...
     </div>
 </section>
+```
+
+### In Python
+
+```python
+from dash import Dash
+from dash.htmlayout import Builder
+
+application = Dash("appname")
+builder = Builder(file="myfile.html")
+application.layout = builder.layout
+
+...
 ```

--- a/src/DOCUMENTATION.md
+++ b/src/DOCUMENTATION.md
@@ -4,6 +4,10 @@ This package provides the ability to build dashboard layouts in Dash by writing 
 
 ## Installation
 
+The package is published on 
+
+![PyPI](https://img.shields.io/badge/pypi-3775A9?style=for-the-badge&logo=pypi&logoColor=white)
+
 You can install this package by using a tool like `pip`:
 
 ```bash
@@ -29,33 +33,36 @@ app.layout = builder.layout
 ### In the HTML file
 
 Since the usual way to build a Dash layout does not involve making the whole HTML5 structure but only what's in the
-`<body>` tag, the same has to be observed in your HTML file. For example:
+`<body>` tag, the same has to be observed in your HTML/XML file. For example:
 
 ```html
 <section>
     <h1 id="dash-title">Title</h1>
-    <dcc.dropdown id="select-1" data-list-options-0="Red" data-list-options-1="Blue"/>
+    <dcc-dropdown id="select-1" data-options="['Red', 'Blue']"/>
 </section>
 ```
 
+Only HTML comments and tags backed up by a component offered by the Dash libraries would be
+accepted in your document.
+
+### Non-string parameters
+
 Any parameter for a component class can be defined as a tag attribute, as long as it is a
-`str`. 
-
-Parameters of type `list[str]` can be provided in HTML using the following scheme:
+`str`. Parameters that are not of type `str` can be provided in HTML using the following scheme:
 
 ```html
-<div data-list-parameter-0="first item" data-list-parameter-1="second item" ...>
+<div data-parameter="python literal to evaluate" ...>
 ```
 
-Parameters of type `bool` can be provided in HTML using the following scheme:
+For example, the `Dropdown` and `Slider` components from `dash.dcc` accept some arguments that are lists or integers, like `options` and `value`. You may pass those in HTML like follows:
 
 ```html
-<div data-bool-parameter1="1">
+<dcc-slider data-value="1" data-min="0" data-max="10" data-step="5" />
+<dcc-dropdown data-options="['Option 1', 'Option 2']" />
 ```
 
-**Note**: Text that will be considered `True` is `"1"`, `"true"`, `"yes"` or `"on"`
-
-
+Every attribute starting with the name `data-<name>` will be treated as the argument `<name>`, with its text value
+evaluated as a Python literal.
 
 ### What tag names to use for non-HTML components?
 
@@ -64,7 +71,10 @@ Generally, the prefix is the most relevant part of the module name, eg. `table` 
 The prefix must be used as following:
 
 ```html
-<dcc.dropdown/>
-<table.datatable/>
-<daq.booleanswitch on=false/>
+<dcc-dropdown/>
+<table-datatable/>
+<daq-booleanswitch data-on="False"/>
 ```
+
+Dot notation is not used for prefixing because it interferes with content editor helpers like Emmet, and
+will be considered as a class.

--- a/src/dash/htmlayout/converters.py
+++ b/src/dash/htmlayout/converters.py
@@ -1,0 +1,16 @@
+from typing import Any
+from ast import literal_eval
+
+
+def evaluate(string: str) -> Any:
+    """
+    Evaluate a string in an HTML attribute to Python.
+
+    Args:
+        string: text passed as an attribute.
+
+    Returns:
+        A Python literal.
+
+    """
+    return literal_eval(string)

--- a/tests/files/simple.html
+++ b/tests/files/simple.html
@@ -1,0 +1,4 @@
+<!-- Comments should be properly ignored -->
+<section id="content">
+    <dcc-dropdown data-options="['Red', 'Blue']"/>
+</section>

--- a/tests/test_builder.py
+++ b/tests/test_builder.py
@@ -1,0 +1,14 @@
+import unittest
+
+from src.dash.htmlayout import Builder
+
+
+class BuilderTestCase(unittest.TestCase):
+    def setUp(self):
+        self.builder = Builder(file="files/simple.html")
+
+    def test_simple_file(self):
+        print(self.builder.layout)
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Changed builder to simplify argument building from HTML tag attributes. Arguments of any literal type can be built by using a `data-` prefix to the argument name, and putting the literal in the attribute string.

Updated documentation to follow the changes more closely.

Added an initial test (not working at the moment).